### PR TITLE
Docs: clarify sandbox purpose and sandbox→datasets mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,61 @@ when the public record genuinely requires split designs (see existing folders).
 
 ## Sandbox (under preparation)
 
-Work-in-progress or **not-yet-valid** annotations live under **`sandbox/`** (see
-[`sandbox/README.md`](sandbox/README.md)). Typical reasons include empty
-placeholders, drafts, or files that **fail** `parse_sdrf validate-sdrf` until they
-are repaired. **CI only enforces validation on `datasets/`**; `sandbox/` is
-exempt so contributors can iterate without blocking merges on known-broken rows.
-When an accession is ready, **move** its folder from `sandbox/` into `datasets/`
-and open a pull request so checks run on the canonical path.
+### What `sandbox/` is for
+
+`sandbox/` is a **staging area** for SDRFs that are not yet ready to live
+alongside the production annotations in `datasets/`. Put an accession here when
+any of the following is true:
+
+- The file **fails** `parse_sdrf validate-sdrf` (structural errors, ontology
+  mismatches, template-level violations).
+- The file is an **empty placeholder** or stub reserving the accession while
+  annotation is in progress.
+- The annotation is a **draft** that still needs review against the PX landing
+  page, the publication, or raw files.
+- The file was migrated from an external source and has **known issues** a
+  reviewer plans to repair.
+
+If the SDRF already passes validation, **do not** put it in `sandbox/` — it
+belongs in `datasets/`.
+
+### Why this split exists
+
+CI validation (`parse_sdrf validate-sdrf`, GitHub Actions) runs **only** on
+files under `datasets/**`. Files under `sandbox/**` are deliberately **exempt**
+so contributors can iterate on broken SDRFs and open PRs without blocking
+merges on known-failing rows. The tradeoff: `sandbox/` files are not guaranteed
+valid at any point in time, while anything under `datasets/` must pass CI.
+
+Layout in both trees is identical:
+`{datasets,sandbox}/{ACCESSION}/{ACCESSION}.sdrf.tsv` (additional
+`*.sdrf.tsv` files in the same accession folder are allowed when the public
+record requires split designs). See also [`sandbox/README.md`](sandbox/README.md).
+
+### How to promote from `sandbox/` → `datasets/`
+
+When a sandbox SDRF is finally clean, move it to `datasets/` in a **dedicated
+pull request**:
+
+1. **Validate locally** against the current validator:
+   ```bash
+   pip install git+https://github.com/bigbio/sdrf-pipelines@main
+   parse_sdrf validate-sdrf --sdrf_file sandbox/{ACC}/{ACC}.sdrf.tsv
+   ```
+   Fix every error before continuing; warnings can be addressed in review.
+2. **Move the folder** with `git mv` so file history is preserved:
+   ```bash
+   git mv sandbox/{ACC} datasets/{ACC}
+   ```
+3. **Commit** with a message that names the accession and states the promotion,
+   e.g. `Promote {ACC} from sandbox/ to datasets/.`
+4. **Open a PR** whose diff shows only the rename (and any small fixes made in
+   the same pass). Keep unrelated edits out so review stays tight.
+5. CI will now validate the file on the canonical path. Merge once the
+   `validate` job is green.
+
+If a file already under `datasets/` regresses later, move it back to `sandbox/`
+the same way and open an issue or PR describing the regression.
 
 ## Migration context
 

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -5,11 +5,14 @@ for the canonical `datasets/` tree: empty placeholders, drafts, or files that
 **do not pass** `parse_sdrf validate-sdrf` with the current
 [`sdrf-pipelines`](https://github.com/bigbio/sdrf-pipelines) `main` branch.
 
+See the [root README](../README.md#sandbox-under-preparation) for the full
+explanation of what `sandbox/` is for and why it exists.
+
 ## Rules
 
 - **`datasets/`** — Only SDRF files that pass CI validation belong here.
 - **`sandbox/`** — Anything under active curation, repair, or migration. Fix the
-  SDRF here, validate locally, then **move** the accession folder into
+  SDRF here, validate locally, then **promote** the accession folder into
   `datasets/` in a dedicated pull request.
 
 ## Layout
@@ -25,3 +28,25 @@ GitHub Actions **does not** require `sandbox/**/*.sdrf.tsv` to pass validation. 
 only enforces checks on paths under `datasets/`. Pushes that touch only `sandbox/`
 still trigger the workflow so the job can validate `datasets/` when both areas
 change in one PR.
+
+## Promoting a sandbox accession to `datasets/`
+
+When a sandbox SDRF finally passes validation, move it with `git mv` so history
+follows the file:
+
+```bash
+# 1. Validate locally
+pip install git+https://github.com/bigbio/sdrf-pipelines@main
+parse_sdrf validate-sdrf --sdrf_file sandbox/{ACC}/{ACC}.sdrf.tsv
+
+# 2. Move and commit
+git mv sandbox/{ACC} datasets/{ACC}
+git commit -m "Promote {ACC} from sandbox/ to datasets/."
+
+# 3. Push and open a PR
+git push -u origin promote/{ACC}
+```
+
+Keep the diff scoped to the rename plus any small fixes made in the same pass.
+CI will then validate the file on the canonical path. Merge once the `validate`
+job is green.


### PR DESCRIPTION
## Summary
- split the Sandbox section in the root `README.md` into three subsections: **what `sandbox/` is for**, **why the split exists**, and **how to promote from `sandbox/` → `datasets/`**
- add a numbered, copy-pasteable promotion procedure (validate locally, `git mv`, scoped PR, CI re-checks)
- cross-link `sandbox/README.md` back to the root section and mirror the step-by-step commands so contributors who land in `sandbox/` directly can act without hopping to the root

## Motivation
The previous Sandbox section described the folder in one paragraph but did not
explain *when* an accession belongs there vs. in `datasets/`, and did not spell
out the promotion mechanism. This PR makes both explicit.

## Test plan
- [ ] Read the updated Sandbox section in the root README and confirm the three subsections answer: what / why / how
- [ ] Confirm the `git mv` + commit + PR steps match repository conventions