### PR TITLE
Add dynamic README badges

### DIFF
--- a/.github/badges/datasets.json
+++ b/.github/badges/datasets.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "datasets",
+  "message": "281",
+  "color": "1f6feb"
+}

--- a/.github/badges/llms-txt.json
+++ b/.github/badges/llms-txt.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "llms.txt",
+  "message": "available",
+  "color": "blue"
+}

--- a/.github/badges/sandbox.json
+++ b/.github/badges/sandbox.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "sandbox",
+  "message": "7",
+  "color": "7a3cff"
+}

--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -1,0 +1,88 @@
+name: Update README Badge Metrics
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - ".github/badges/**"
+  schedule:
+    - cron: "20 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  refresh-badges:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Recompute badge JSON
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          repo = Path(".")
+          badge_dir = repo / ".github" / "badges"
+          badge_dir.mkdir(parents=True, exist_ok=True)
+
+          def count_annotation_dirs(path: Path) -> int:
+              if not path.exists():
+                  return 0
+              return sum(
+                  1
+                  for child in path.iterdir()
+                  if child.is_dir() and any(child.glob("*.sdrf.tsv"))
+              )
+
+          llms_available = (repo / "llms.txt").is_file()
+          datasets_count = count_annotation_dirs(repo / "datasets")
+          sandbox_count = count_annotation_dirs(repo / "sandbox")
+
+          badges = {
+              "llms-txt.json": {
+                  "schemaVersion": 1,
+                  "label": "llms.txt",
+                  "message": "available" if llms_available else "missing",
+                  "color": "blue" if llms_available else "red",
+              },
+              "datasets.json": {
+                  "schemaVersion": 1,
+                  "label": "datasets",
+                  "message": str(datasets_count),
+                  "color": "1f6feb",
+              },
+              "sandbox.json": {
+                  "schemaVersion": 1,
+                  "label": "sandbox",
+                  "message": str(sandbox_count),
+                  "color": "7a3cff",
+              },
+          }
+
+          for filename, payload in badges.items():
+              (badge_dir / filename).write_text(json.dumps(payload, indent=2) + "\n")
+
+          print("Updated badge metrics:")
+          print(f"  llms.txt: {'available' if llms_available else 'missing'}")
+          print(f"  datasets: {datasets_count}")
+          print(f"  sandbox: {sandbox_count}")
+          PY
+
+      - name: Commit badge updates
+        run: |
+          if git diff --quiet -- .github/badges; then
+            echo "Badge JSON already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges
+          git commit -m "chore: refresh README badge metrics"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # sdrf-annotated-datasets
 
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
+[![llms.txt](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/.github/badges/llms-txt.json)](llms.txt)
+![Datasets](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/.github/badges/datasets.json)
+![Sandbox](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/bigbio/sdrf-annotated-datasets/main/.github/badges/sandbox.json)
+[![Validate SDRF datasets](https://github.com/bigbio/sdrf-annotated-datasets/actions/workflows/validate-sdrf.yml/badge.svg?branch=main)](https://github.com/bigbio/sdrf-annotated-datasets/actions/workflows/validate-sdrf.yml)
+
 Community **SDRF** annotations for public proteomics datasets (ProteomeXchange and
 related accessions). This repository exists so **annotation work can move quickly**
 while the **SDRF specification** stays stable in


### PR DESCRIPTION
## Summary
- add a badge row to the README for license, llms.txt, datasets, sandbox, and validation status
- switch the dataset and sandbox badges to Shields endpoint badges backed by tracked JSON files
- add a GitHub Actions workflow that recomputes the badge JSON on pushes to `main`, on schedule, and on manual dispatch

## Notes
- `datasets` counts top-level dataset folders that contain SDRF files
- `sandbox` counts top-level sandbox folders that contain SDRF files, including PMID-based staging folders and excluding helper directories


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository status badges to README displaying real-time metrics including dataset and sandbox item counts, llms.txt availability indicator, license information, and CI pipeline validation status. Badges are automatically refreshed through continuous integration to keep metrics current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->