### PR TITLE
Review gate: catch casing, encoding, hollow factors, peak lists; fix baseline path no-op

### DIFF
--- a/.github/scripts/sdrf_review.py
+++ b/.github/scripts/sdrf_review.py
@@ -1,20 +1,23 @@
 #!/usr/bin/env python3
 """Self-contained SDRF review gate for CI.
 
-Runs the two checks parse_sdrf is blind to (coordinate collisions, ragged rows)
-plus parse_sdrf validation itself, over the SDRF files given as arguments.
+Runs the checks parse_sdrf is blind to -- coordinate collisions, ragged rows,
+reserved-word casing, characteristics value encoding, hollow/missing factor values,
+pandas artifact headers and peak-list data files -- plus parse_sdrf validation itself,
+over the SDRF files given as arguments.
 Canonical logic lives in the sdrf-harness package (validator.py); this is a
 vendored, dependency-light copy so CI needs only sdrf-pipelines.
 
 Usage: python sdrf_review.py [--baseline <dir>] <file.sdrf.tsv> [more...]
 Exit 0 if all clean (warnings allowed), 1 if any defect.
 
-With --baseline <dir>, structural defects (coordinate collisions, ragged rows) are
+With --baseline <dir>, structural and content defects are
 reported only when the file INTRODUCES them: a file that already had N collisions on
 the base branch (a copy of which lives at <dir>/<path>) and still has <= N is not
 flagged, so a change that never touches the coordinate columns is not blocked by a
 pre-existing defect. parse_sdrf validity is always checked in full.
 """
+import re
 import subprocess
 import sys
 from collections import Counter
@@ -38,6 +41,78 @@ def structural_check(path):
         key = Counter((r[0], r[bi], r[ti], r[fr]) for r in rows if len(r) > max(bi, ti, fr))
         collisions = sum(1 for v in key.values() if v > 1)
     return ragged, collisions
+
+
+SENTINELS = {"not available", "not applicable"}
+RESERVED = SENTINELS | {"pooled", "normal"}
+PEAK_LIST = (".mgf", ".mzml", ".mzxml")
+
+
+def _baseline_path(baseline, f):
+    """Map a reviewed file to its copy under <baseline>.
+
+    Path(baseline) / "/abs/path" returns "/abs/path" -- an absolute argument would
+    silently make the baseline the file itself and disable every check, so strip the
+    anchor first and always resolve inside the baseline tree.
+    """
+    p = Path(f)
+    rel = p.relative_to(p.anchor) if p.is_absolute() else p
+    return Path(baseline) / rel
+
+
+def content_check(path):
+    """Defects parse_sdrf does not catch. Returns {defect_name: count}."""
+    lines = Path(path).read_text(encoding="utf-8", errors="ignore").splitlines()
+    if not lines:
+        return {}
+    hdr = lines[0].split("\t")
+    H = [c.strip().lower() for c in hdr]
+    rows = [ln.split("\t") for ln in lines[1:] if ln.strip()]
+    d = Counter()
+
+    # header mangled by pandas: comment[x].1 is NOT the same column as comment[x]
+    d["artifact_headers"] = sum(1 for c in hdr if re.search(r"\]\.\d+$", c.strip()))
+
+    if not rows:
+        return {k: v for k, v in d.items() if v}
+
+    def cell(r, i):
+        return r[i].strip() if i < len(r) else ""
+
+    for i, name in enumerate(H):
+        for r in rows:
+            v = cell(r, i)
+            if not v:
+                continue
+            # reserved words MUST be lowercase (spec); parse_sdrf does not check this
+            if v.lower() in RESERVED and v != v.lower():
+                d["reserved_word_case"] += 1
+            # characteristics take the bare ontology label, not NT=;AC=
+            elif name.startswith("characteristics[") and "=" in v:
+                parts = [p for p in v.split(";") if p.strip()]
+                keys = set()
+                pure = True
+                for p in parts:
+                    if "=" not in p:
+                        pure = False
+                        break
+                    keys.add(p.split("=", 1)[0].strip().upper())
+                if pure and keys == {"NT", "AC"}:
+                    d["characteristics_not_bare_label"] += 1
+        # vendor RAW, not peak lists
+        if name == "comment[data file]":
+            d["peak_list_data_file"] += sum(
+                1 for r in rows if cell(r, i).lower().endswith(PEAK_LIST))
+
+    # factor value: must exist and must encode an actual contrast
+    fi = [i for i, c in enumerate(H) if c.startswith("factor value[")]
+    if not fi:
+        d["no_factor_value"] = 1
+    elif all(cell(r, i).lower() in SENTINELS or not cell(r, i)
+             for i in fi for r in rows):
+        d["hollow_factor_value"] = 1
+
+    return {k: v for k, v in d.items() if v}
 
 
 def parse_sdrf_ok(path):
@@ -67,11 +142,19 @@ def main(argv):
         # that does not touch the coordinate columns is not blocked by a pre-existing defect.
         base_ragged = base_collisions = 0
         if baseline:
-            bpath = Path(baseline) / f
+            bpath = _baseline_path(baseline, f)
             if bpath.exists() and bpath.stat().st_size > 0:
                 base_ragged, base_collisions = structural_check(bpath)
         new_collisions = max(0, collisions - base_collisions)
         new_ragged = max(0, ragged - base_ragged)
+        cont = content_check(f)
+        base_cont = {}
+        if baseline:
+            bp = _baseline_path(baseline, f)
+            if bp.exists() and bp.stat().st_size > 0:
+                base_cont = content_check(bp)
+        new_cont = {k: v - base_cont.get(k, 0) for k, v in cont.items()
+                    if v - base_cont.get(k, 0) > 0}
         ok, last = parse_sdrf_ok(f)
         problems = []
         if new_collisions:
@@ -79,6 +162,8 @@ def main(argv):
             problems.append(f"{new_collisions} new coordinate collisions{pre}")
         if new_ragged:
             problems.append(f"{new_ragged} new ragged rows")
+        for k, v in sorted(new_cont.items()):
+            problems.append(f"{v} {k}")
         if not ok:
             problems.append(f"parse_sdrf: {last}")
         status = "OK" if not problems else "FAIL"


### PR DESCRIPTION
Prevention half of the corpus adversarial review — the defects found in bulk were invisible to both `parse_sdrf` and the existing gate, so nothing stops them re-entering.

### New checks
| Check | What it catches | Corpus hits before cleanup |
|---|---|---|
| `reserved_word_case` | `Not available` where the spec requires lowercase | 1,142 files |
| `characteristics_not_bare_label` | `NT=…;AC=…` in a `characteristics[...]` column | 1,152 files |
| `hollow_factor_value` | factor column present but entirely sentinels — encodes no contrast | 1,092 files |
| `no_factor_value` | no `factor value[...]` column at all | 750 files |
| `peak_list_data_file` | `.mgf`/`.mzML`/`.mzXML` in `comment[data file]` | 20 files |
| `artifact_headers` | pandas `.1` suffixes on repeated columns | 4 files |

`parse_sdrf` reports *"Most seems to be fine"* on a file with 428 wrong-cased reserved words — that is why these need to live in the gate.

### Baseline-aware
Like the existing structural checks, a PR is blocked only for defects it **introduces or worsens**; the corpus's existing debt never blocks unrelated work. Verified with 6 cases: clean→clean passes; introducing casing / NT-AC / peak-list each fails; pre-existing casing unchanged passes; pre-existing + newly added defect fails.

### Latent no-op fixed
`Path(baseline) / f` returns `f` unchanged when `f` is absolute — that would silently make the baseline *the file itself* and disable **every** check, reporting a clean run. CI passes relative paths so the gate worked, but the failure mode was silent. Paths are now always resolved inside the baseline tree.

Pairs with #106 (the mechanical cleanup); this PR touches only the gate script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SDRF validation to detect additional content issues, including inconsistent reserved-word casing and malformed ontology values.
  * Added checks for missing or empty factor values, altered column headers, and unsupported peak-list file formats.
  * Enhanced review results to distinguish newly introduced content defects from existing baseline issues.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->