### PR TITLE
Review gate: include comment[label] in the coordinate-collision key

### DIFF
--- a/.github/scripts/sdrf_review.py
+++ b/.github/scripts/sdrf_review.py
@@ -36,9 +36,16 @@ def structural_check(path):
     bi, ti, fr = (col("characteristics[biological replicate]"),
                   col("comment[technical replicate]"),
                   col("comment[fraction identifier]"))
+    # comment[label] is part of the identity: in multiplexed data (TMT/SILAC) the same
+    # sample+replicate+fraction legitimately repeats once per label channel of one raw
+    # file. Excluding the label flags every correct SILAC/TMT annotation as a collision.
+    lb = col("comment[label]")
     collisions = 0
     if None not in (bi, ti, fr):
-        key = Counter((r[0], r[bi], r[ti], r[fr]) for r in rows if len(r) > max(bi, ti, fr))
+        need = max(x for x in (bi, ti, fr, lb) if x is not None)
+        key = Counter(
+            (r[0], r[bi], r[ti], r[fr]) + ((r[lb],) if lb is not None else ())
+            for r in rows if len(r) > need)
         collisions = sum(1 for v in key.values() if v > 1)
     return ragged, collisions
 


### PR DESCRIPTION
**The live gate currently blocks correct multiplexed annotations.** Found while triaging the 79 coordinate collisions from the corpus review.

### The bug
The collision key is `(source name, biological replicate, technical replicate, fraction identifier)`. In TMT/SILAC data that tuple **legitimately repeats once per label channel** of a single raw file, so a correct multiplex annotation is reported as colliding.

### Evidence
`PXD006430-silac`, coordinate `('Sample 1','1','1','1')` — two rows:

| label | assay | data file |
|---|---|---|
| SILAC heavy | run 1 | `…SILACplate1_1mgIPG25-37_fr01.raw` |
| SILAC light | run 1 | `…SILACplate1_1mgIPG25-37_fr01.raw` |

Same raw file, two channels — exactly how SILAC is meant to be annotated. The spec's MUST-unique key (`source name` + `assay name` + `comment[label]`) has **0 duplicates** here: the file is right, the gate was wrong.

### The fix, and that it still catches real defects
Adding `comment[label]` to the key drops `PXD006430-silac` to **0** collisions, while `PXD010429` — where `Fx01`, `Fx02`, `Fx03`, `Fx04` all carry `fraction identifier = 1` under the same `TMT126` label — still reports **348**.

Corpus-wide: **79 flagged files → 60 real ones**, 19 false positives removed. `comment[label]` is optional, so the key falls back to the previous tuple when the column is absent.