### PR TITLE
Review gate: do not flag collisions the annotation already explains

### DIFF
--- a/.github/scripts/sdrf_review.py
+++ b/.github/scripts/sdrf_review.py
@@ -43,10 +43,30 @@ def structural_check(path):
     collisions = 0
     if None not in (bi, ti, fr):
         need = max(x for x in (bi, ti, fr, lb) if x is not None)
-        key = Counter(
-            (r[0], r[bi], r[ti], r[fr]) + ((r[lb],) if lb is not None else ())
-            for r in rows if len(r) > need)
-        collisions = sum(1 for v in key.values() if v > 1)
+        groups = {}
+        for r in rows:
+            if len(r) <= need:
+                continue
+            k = (r[0], r[bi], r[ti], r[fr]) + ((r[lb],) if lb is not None else ())
+            groups.setdefault(k, []).append(r)
+        dup = [v for v in groups.values() if len(v) > 1]
+        # A collision is only a defect if the file does not record the distinction
+        # anywhere. Multi-dimensional designs (a second fractionation scheme, an
+        # enrichment arm, a preparation batch) repeat the coordinate legitimately and
+        # carry the distinguishing value in another column, so a group that some
+        # descriptive column separates completely is annotated, not colliding.
+        # Identity columns are excluded: comment[data file] differing IS the collision,
+        # and assay name/source name are derived run labels, not sample description.
+        if dup:
+            ignore = {"source name", "assay name", "comment[data file]", "comment[file uri]"}
+            explainers = [i for i, name in enumerate(h)
+                          if name.strip().lower() not in ignore
+                          and (name.strip().lower().startswith(("characteristics[", "comment["))
+                               or name.strip().lower().startswith("factor value["))]
+            explained = any(
+                all(len({r[i] if i < len(r) else "" for r in v}) == len(v) for v in dup)
+                for i in explainers)
+            collisions = 0 if explained else len(dup)
     return ragged, collisions
 
 


### PR DESCRIPTION
A repeated coordinate is only a defect when the file records **nothing** that tells the runs apart. Multi-dimensional designs repeat it legitimately.

### Evidence
- **PXD061609** runs three SAX schemes over the same 24 fractions. Its submitter-deposited `KEY.xlsx` maps every raw file to (scheme, fraction) and confirms the SDRF's fraction numbers are **correct**; the distinction is carried in `comment[sample preparation batch]` (NoSAX / HighSalt / LowSalt). 432 "collisions" — all correct annotation.
- **PXD011799** is the same shape via `characteristics[enrichment process]` (global vs TiO2 phospho).

### The rule
A colliding group counts as annotated when **some descriptive column separates it completely**. Identity columns are excluded so this cannot become a loophole:
- `comment[data file]` differing **is** the collision;
- `assay name` and `source name` are derived run labels, not sample description.

### Effect
Corpus-wide **60 → 44** flagged files. Genuine defects stay flagged: `PXD006233` (171) and `PXD009602` (145), where nothing but the raw file differs, are untouched by this change.

Stacks on #109 (label-aware key). Together: 79 → 44, all 35 removals verified as correct annotations rather than suppressed defects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-row validation by recognizing when distinguishing metadata makes repeated coordinate entries valid.
  * Prevented misleading collision reports for duplicate entries that are uniquely identified by their characteristics, comments, or factor values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->