### PR TITLE
Review gate: make peak-list and missing-factor-value advisory, not blocking

### DIFF
--- a/.github/scripts/sdrf_review.py
+++ b/.github/scripts/sdrf_review.py
@@ -70,6 +70,13 @@ def structural_check(path):
     return ragged, collisions
 
 
+# Advisory findings: reported so they are visible, but they do not fail the gate.
+# - peak lists are sometimes all a public deposit contains, so the annotation is
+#   faithful to the data that exists and there is no vendor RAW to point at
+# - a factor value is recommended, not required: a single-condition descriptive
+#   study has no contrast to encode and a placeholder would be worse than none
+ADVISORY = {"peak_list_data_file", "no_factor_value"}
+
 SENTINELS = {"not available", "not applicable"}
 RESERVED = SENTINELS | {"pooled", "normal"}
 PEAK_LIST = (".mgf", ".mzml", ".mzxml")
@@ -189,15 +196,21 @@ def main(argv):
             problems.append(f"{new_collisions} new coordinate collisions{pre}")
         if new_ragged:
             problems.append(f"{new_ragged} new ragged rows")
+        advisories = []
         for k, v in sorted(new_cont.items()):
-            problems.append(f"{v} {k}")
+            (advisories if k in ADVISORY else problems).append(f"{v} {k}")
         if not ok:
             problems.append(f"parse_sdrf: {last}")
         status = "OK" if not problems else "FAIL"
         note = ""
-        if not problems and (collisions or ragged):
+        if advisories:
+            note = " — advisory: " + "; ".join(advisories)
+        elif not problems and (collisions or ragged):
             note = f" — pre-existing {collisions} collisions/{ragged} ragged (not introduced here)"
-        print(f"[{status}] {f}" + (" — " + "; ".join(problems) if problems else note))
+        detail = "; ".join(problems)
+        if problems and advisories:
+            detail += " (advisory: " + "; ".join(advisories) + ")"
+        print(f"[{status}] {f}" + (" — " + detail if problems else note))
         if problems:
             failures.append(f)
     print(f"\n{len(files) - len(failures)}/{len(files)} clean, {len(failures)} with defects")


### PR DESCRIPTION
Both checks landed as **blocking** in #107 and both are too strict in practice. They are now **reported but non-blocking**.

### Peak lists (`peak_list_data_file`)
Some public deposits contain **only converted files** — there is no vendor RAW to point at. Refusing those annotations does not produce raw data, it just leaves the dataset unannotated. An SDRF that faithfully references what the deposit actually holds should pass. Blocking #177 (287 references) and #179 (11).

### Factor value (`no_factor_value`)
The spec treats a factor value as **recommended, not required**. A single-condition descriptive study has no contrast to encode, and forcing a column yields a placeholder that is *worse* than its absence — precisely the **hollow factor value** this same gate flags elsewhere. Blocking #199, #194, #188, #156.

### Behaviour
Both are still detected and printed on the result line so they stay visible in review; they simply no longer set the exit status:

```
[OK] datasets/MSV000078958/….sdrf.tsv — advisory: 287 peak_list_data_file
[FAIL] datasets/X/X.sdrf.tsv — 1 new coordinate collisions (advisory: 2 peak_list_data_file)
```

### Verified
Against the real files from the PRs they were blocking: **#177 and #199 now exit 0** with the finding shown as advisory. Structural defects are unaffected — a coordinate collision in the same file still fails, and a file with both fails on the collision with the advisory reported alongside.

Unblocks #177, #179, #199, #194, #188, #156.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added advisory notices for peak-list data files and missing factor values.
  * Advisory findings are displayed separately from review-blocking failures.
  * Reviews now pass when only advisory issues are detected, while other content defects continue to block approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->