### PR TITLE
Stop automated README stats PRs from always conflicting

### DIFF
--- a/.github/workflows/update-readme-stats.yml
+++ b/.github/workflows/update-readme-stats.yml
@@ -9,6 +9,14 @@ on:
       - ".github/workflows/update-readme-stats.yml"
   workflow_dispatch:
 
+# Dataset merges often land in a burst. Each push used to start its own job
+# against the same reused chore/readme-resource-stats branch. create-pull-request
+# then rebases an older stats commit onto a newer README/docs/stats snapshot
+# and the standing PR stays conflicted (#266 / #265 race).
+concurrency:
+  group: update-readme-resource-stats
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -21,6 +29,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: main
+
+      - name: Sync to latest main
+        run: |
+          git fetch origin main
+          git checkout main
+          git reset --hard origin/main
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -36,12 +51,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python .github/scripts/generate_readme_stats.py
 
+      - name: Reset standing stats branch onto current main
+        run: |
+          # create-pull-request rebases the existing PR branch onto this
+          # checkout. That rebase conflicts whenever main already has a later
+          # README/docs/stats commit (previous stats PR merge, badge commit
+          # sitting under a newer stats snapshot, or a human stats merge).
+          # Point the reused branch at current main first so the action only
+          # adds one fresh commit and cannot replay a stale stats snapshot.
+          git push origin "HEAD:refs/heads/chore/readme-resource-stats" --force
+
       - name: Open or update stats PR
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: refresh README resource stats"
           branch: chore/readme-resource-stats
+          base: main
           delete-branch: true
           title: "chore: refresh README resource stats"
           body: |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why #266 always conflicts

https://github.com/bigbio/sdrf-annotated-datasets/pull/266 is the standing `chore: refresh README resource stats` PR from `.github/workflows/update-readme-stats.yml`. It is not a one-off merge problem.

Dataset PRs often land on `main` in a burst. Each push starts the same workflow, and every run updates the **same** reused branch (`chore/readme-resource-stats`) through `peter-evans/create-pull-request`. That action **rebases the previous stats commit** onto the job checkout. Both sides rewrite `README.md` and `docs/stats/**`, so the rebase (and GitHub’s merge) stay conflicted.

The #265 / #266 race is the concrete case:

- Several dataset merges between 17:54–17:55 UTC each started a stats job.
- #265 was opened at 17:55:43 and merged at 17:55:56.
- #266 was opened two seconds later from a checkout still based on #260, so it was missing the badge commit and the #265 stats snapshot. GitHub reported `CONFLICTING` / `DIRTY` because both commits edit the same generated files.

`delete-branch: true` does not help while the PR is still open, and it does not stop the next overlapping run from replaying a stale snapshot.

## What this PR changes

- **Concurrency group** `update-readme-resource-stats` with `cancel-in-progress: true` so a burst of dataset merges keeps only the latest refresh.
- **Always check out and hard-reset `origin/main`** before generating, instead of the triggering (possibly already-stale) push SHA.
- **Force-point `chore/readme-resource-stats` at current `main`** before `create-pull-request` runs, so the action cannot rebase an older README/stats commit. It only adds one fresh commit.
- Set **`base: main`** explicitly.

## Evidence

- #265: created 17:55:43, merged 17:55:56, head `chore/readme-resource-stats`
- #266 (before reset): created 17:55:58, merge-base `#260` (`52710b7a`), behind `main` by the badge commit plus #265
- Workflow run list: seven `Update README resource stats` jobs started within about one minute

## Current status

#266 was reset onto current `main` and regenerated (6,237 → 6,252 accessions; the previous snapshot had been built from a stale checkout). GitHub now reports it `MERGEABLE` / `CLEAN` (1 commit ahead, 0 behind). Merge this workflow fix so the next dataset burst does not recreate the conflict loop.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-721e8dbc-ad95-4e37-bfe5-ffd1db676145?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-721e8dbc-ad95-4e37-bfe5-ffd1db676145&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated resource-stat updates by ensuring generated results use the latest main branch.
  * Prevented overlapping update runs from creating conflicting changes.
  * Updated the automated workflow to keep statistics changes synchronized with the main project branch.
  * Improved reliability of pull requests generated for resource-stat updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->