### PR TITLE
Retry README stats generation when main moves mid-job

### DIFF
--- a/.github/workflows/update-readme-stats.yml
+++ b/.github/workflows/update-readme-stats.yml
@@ -49,17 +49,30 @@ jobs:
         env:
           MPLCONFIGDIR: /tmp/matplotlib
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python .github/scripts/generate_readme_stats.py
-
-      - name: Reset standing stats branch onto current main
         run: |
-          # create-pull-request rebases the existing PR branch onto this
-          # checkout. That rebase conflicts whenever main already has a later
-          # README/docs/stats commit (previous stats PR merge, badge commit
-          # sitting under a newer stats snapshot, or a human stats merge).
-          # Point the reused branch at current main first so the action only
-          # adds one fresh commit and cannot replay a stale stats snapshot.
-          git push origin "HEAD:refs/heads/chore/readme-resource-stats" --force
+          set -euo pipefail
+          # Generation takes ~1–2 minutes. A standing stats PR can be merged
+          # in that window (#270 merged while the #269 job was still running,
+          # which then opened conflicted #271 from the pre-merge main tip).
+          # Rebuild from origin/main whenever it moves, and only publish the
+          # reused branch once HEAD still matches current main.
+          for attempt in 1 2 3; do
+            git fetch origin main
+            git checkout main
+            git reset --hard origin/main
+            base="$(git rev-parse HEAD)"
+            echo "Generating stats from ${base} (attempt ${attempt})"
+            python .github/scripts/generate_readme_stats.py
+            git fetch origin main
+            if [ "$(git rev-parse origin/main)" = "${base}" ]; then
+              echo "main still at ${base}; resetting chore/readme-resource-stats"
+              git push origin "HEAD:refs/heads/chore/readme-resource-stats" --force
+              exit 0
+            fi
+            echo "main moved to $(git rev-parse origin/main) during generation; retrying"
+          done
+          echo "main kept moving during stats generation" >&2
+          exit 1
 
       - name: Open or update stats PR
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why #271 conflicted

https://github.com/bigbio/sdrf-annotated-datasets/pull/271 is the same standing `chore/readme-resource-stats` PR as #266. #268 stopped the rebase-onto-stale-branch loop, but a second race remained:

- #270 sat open from 18:29 UTC.
- #269 landed and started a stats job at 19:53:36 (checkout was `main` at #269).
- #270 was merged at 19:54:09 **while that job was still generating**.
- The finishing job force-pointed `chore/readme-resource-stats` at the pre-merge tip and opened #271 at 19:55:26. GitHub then compared that snapshot to #270’s already-merged `README.md` / `docs/stats/**` and reported `CONFLICTING`.

Generation takes about 1–2 minutes, so merging a standing stats PR during a later dataset-triggered run is enough to recreate the conflict.

## What this PR changes

After each generation pass the workflow re-fetches `origin/main`. If `main` moved (stats merge, badge commit, another dataset), it discards the stale snapshot and regenerates, up to three times. It only force-updates `chore/readme-resource-stats` when `HEAD` still matches current `main`.

## Current status

#271 was reset onto current `main` and regenerated (6,254 accessions). GitHub now reports it `MERGEABLE` / `CLEAN` (1 commit ahead, 0 behind). Merge this workflow change so the next mid-job merge does not put the standing stats PR back into conflict.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-721e8dbc-ad95-4e37-bfe5-ffd1db676145?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-721e8dbc-ad95-4e37-bfe5-ffd1db676145&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the automated README statistics update process.
  * Added retry handling to prevent updates from overwriting newer changes on the main branch.
  * The process now stops with an error if the main branch changes repeatedly during generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->