### PR TITLE
Gate: flag an instrument that cannot have written the deposited files

### DIFF
--- a/.github/scripts/sdrf_review.py
+++ b/.github/scripts/sdrf_review.py
@@ -81,6 +81,60 @@ SENTINELS = {"not available", "not applicable"}
 RESERVED = SENTINELS | {"pooled", "normal"}
 PEAK_LIST = (".mgf", ".mzml", ".mzxml")
 
+# A vendor's acquisition software writes its own container format, so an instrument that
+# could not physically have produced the deposited files is a hard contradiction -- one that
+# needs no protocol text and admits no judgement. It catches an instrument copied from an
+# archive's metadata dropdown without checking it against the deposit.
+VENDOR_PATTERNS = (
+    (re.compile(r"orbitrap|q\s*exactive|ltq|exploris|astral|velos|lcq|fusion|lumos|ascend",
+                re.I), "thermo"),
+    (re.compile(r"timstof|maxis|impact|amazon|hct|ultraflex|autoflex", re.I), "bruker"),
+    (re.compile(r"triple\s*tof|qstar|q\s*trap|x500|zenotof", re.I), "sciex"),
+    (re.compile(r"synapt|xevo", re.I), "waters"),
+)
+VENDOR_EXT = {
+    "thermo": (".raw", ".raw.zip"),
+    "bruker": (".d", ".d.zip", ".d.7z", ".d.tar", ".baf", ".yep", ".tdf", ".fid"),
+    "sciex": (".wiff", ".wiff.zip"),
+    # Waters .raw is a directory, usually deposited as an archive
+    "waters": (".raw", ".raw.zip"),
+}
+# Converted formats are vendor-neutral and never contradict an instrument.
+NEUTRAL_EXT = (".mzml", ".mzxml", ".mgf")
+ALL_VENDOR_EXT = tuple(sorted({e for exts in VENDOR_EXT.values() for e in exts} | set(NEUTRAL_EXT),
+                              key=len, reverse=True))
+
+
+def _vendor_of(instrument):
+    """Manufacturer implied by an instrument model, or None if not recognised."""
+    for pattern, vendor in VENDOR_PATTERNS:
+        if pattern.search(instrument):
+            return vendor
+    return None
+
+
+def instrument_vendor_check(instruments, data_files):
+    """Count files whose format the declared instrument's vendor cannot write.
+
+    Silent whenever it cannot judge: an unrecognised model, no data files, or a file
+    extension outside the known set. Several declared instruments means a row may
+    legitimately match any of them, so a file only counts when NO declared instrument
+    could have written it.
+    """
+    vendors = {v for v in (_vendor_of(i) for i in instruments) if v}
+    if not vendors or not data_files:
+        return 0
+    allowed = set(NEUTRAL_EXT)
+    for v in vendors:
+        allowed |= set(VENDOR_EXT[v])
+    bad = 0
+    for f in data_files:
+        low = f.lower()
+        ext = next((e for e in ALL_VENDOR_EXT if low.endswith(e)), None)
+        if ext and ext not in allowed:
+            bad += 1
+    return bad
+
 
 def _baseline_path(baseline, f):
     """Map a reviewed file to its copy under <baseline>.
@@ -137,6 +191,17 @@ def content_check(path):
         if name == "comment[data file]":
             d["peak_list_data_file"] += sum(
                 1 for r in rows if cell(r, i).lower().endswith(PEAK_LIST))
+
+    # an instrument that cannot have written the deposited files
+    ii = [i for i, c in enumerate(H) if c == "comment[instrument]"]
+    fi_data = [i for i, c in enumerate(H) if c == "comment[data file]"]
+    if ii and fi_data:
+        instruments = {re.sub(r"^NT=|;.*$", "", cell(r, i)).strip()
+                       for i in ii for r in rows if cell(r, i)}
+        files = [cell(r, i) for i in fi_data for r in rows if cell(r, i)]
+        bad = instrument_vendor_check(instruments, files)
+        if bad:
+            d["instrument_cannot_write_data_file"] = bad
 
     # factor value: must exist and must encode an actual contrast
     fi = [i for i, c in enumerate(H) if c.startswith("factor value[")]


### PR DESCRIPTION
## An instrument that cannot have written the deposited files

A vendor's acquisition software writes its own container format: Thermo writes `.raw`, Bruker `.d`, SCIEX `.wiff`. An SDRF declaring an instrument that could not physically have produced the files it points at is a **hard contradiction** — and unlike almost every other content defect, it needs no protocol text and admits no judgement.

`parse_sdrf` cannot see it. Both the instrument term and the file name are perfectly valid; only their combination is impossible.

### Why this specific check

I recently put a 390-file batch through an independent adversarial review. Its dominant defect class was values copied from PRIDE's metadata **dropdowns** (`instruments`, `diseases`, `organismParts`) without checking them against the deposit — producing valid CV terms making false statements, all of which passed this gate, `parse_sdrf` and CodeRabbit.

Most of that class needs prose to detect. This one does not, which is why it belongs in CI rather than in an annotator's tooling. In that batch it found exactly 2 contradictions in 390 files with **zero false positives**.

### It is silent wherever it cannot judge

Verified directly:

| Case | Result |
|---|---|
| Thermo instrument, Bruker `.d.zip` files | **2 findings** |
| Thermo instrument, Thermo `.raw` files | none |
| Unrecognised instrument model | none |
| Converted `.mzML` (vendor-neutral) | none |
| Two instruments declared, files match one | none |

### It does not break the 44 existing files

Scanned across **all 7,062 SDRFs on `main`**, it reports 44. Those do not start failing: the workflow reviews only changed files, and the `--baseline` subtraction absorbs a pre-existing count. I confirmed a file whose defect is unchanged between base and head reports **no new defect**. Only a PR that introduces or increases the contradiction fails.

That said, the 44 are real and worth a look. The largest:

| Accession | Files affected | Declared instrument | File formats |
|---|---:|---|---|
| PXD070049 | 649/1049 | `timsTOF Ultra 2` | `.mgf, .raw, .wiff` |
| PXD079292 | 98/98 | `timsTOF HT` | `.raw` |
| PXD004188 | 40/43 | `TripleTOF 5600` | `.raw, .wiff` |
| PXD007535 | 38/57 | `LTQ Orbitrap Velos` | `.raw, .wiff` |
| PXD003358 | 20/20 | `Q Exactive` | `.wiff` |
| PXD004237 | 20/20 | `Q Exactive` | `.wiff` |
| PXD006491 | 20/20 | `Q Exactive` | `.wiff` |
| PXD006604 | 20/20 | `Q Exactive` | `.wiff` |
| PXD026884 | 15/15 | `timstof pro` | `.raw` |
| PXD002354 | 13/18 | `Q Exactive` | `.raw, .wiff` |

<details><summary>All 44</summary>

| Accession | Files affected | Declared instrument | File formats |
|---|---:|---|---|
| PXD070049 | 649/1049 | `timsTOF Ultra 2` | `.mgf, .raw, .wiff` |
| PXD079292 | 98/98 | `timsTOF HT` | `.raw` |
| PXD004188 | 40/43 | `TripleTOF 5600` | `.raw, .wiff` |
| PXD007535 | 38/57 | `LTQ Orbitrap Velos` | `.raw, .wiff` |
| PXD003358 | 20/20 | `Q Exactive` | `.wiff` |
| PXD004237 | 20/20 | `Q Exactive` | `.wiff` |
| PXD006491 | 20/20 | `Q Exactive` | `.wiff` |
| PXD006604 | 20/20 | `Q Exactive` | `.wiff` |
| PXD026884 | 15/15 | `timstof pro` | `.raw` |
| PXD002354 | 13/18 | `Q Exactive` | `.raw, .wiff` |
| PXD068954 | 13/13 | `timsTOF Pro` | `.wiff` |
| PXD023010 | 12/20 | `Q Exactive` | `.raw, .wiff` |
| PXD071582 | 12/12 | `timsTOF SCP` | `.raw` |
| PXD020482 | 9/13 | `Q Exactive HF` | `.raw, .wiff` |
| PXD054800 | 9/9 | `timsTOF Pro` | `.raw` |
| PXD013349 | 8/10 | `LTQ Orbitrap Velos` | `.raw, .wiff` |
| PXD046326 | 8/8 | `timsTOF Pro` | `.raw` |
| PXD001263 | 6/15 | `Q Exactive` | `.raw, .wiff` |
| PXD005408 | 6/6 | `Q Exactive` | `.wiff` |
| PXD027121 | 6/8 | `Orbitrap Fusion` | `.raw, .wiff` |
| PXD031057 | 6/10 | `Orbitrap Fusion` | `.raw, .wiff` |
| PXD033833 | 6/12 | `Orbitrap Fusion Lumos` | `.0ul.wiff, .2ul.wiff, .3ul.wiff` |
| PXD048184 | 6/6 | `timsTOF Pro` | `.raw` |
| PXD052483 | 6/6 | `timsTOF Pro` | `.raw` |
| PXD059495 | 6/6 | `timsTOF Pro` | `.raw` |
| PXD063956 | 6/6 | `autoflex` | `.raw` |
| PXD064315 | 6/6 | `timsTOF Pro` | `.raw` |
| PXD066599 | 6/7 | `Orbitrap Astral` | `.raw, .wiff` |
| PXD070420 | 6/6 | `timsTOF Pro` | `.wiff` |
| PXD072876 | 6/6 | `maxis` | `.raw` |
| PXD001574 | 5/10 | `Q Exactive` | `.raw, .wiff` |
| PXD018672 | 5/16 | `Q Exactive` | `.raw, .wiff` |
| PXD019606 | 5/5 | `ltq orbitrap` | `.wiff` |
| PXD001298 | 4/11 | `Q Exactive` | `.raw, .wiff` |
| PXD057350 | 4/4 | `timsTOF Pro` | `.raw` |
| PXD034594 | 3/6 | `Orbitrap Fusion Lumos` | `.raw, .wiff` |
| PXD077606 | 3/3 | `timsTOF Pro` | `.raw` |
| PXD005542 | 2/2 | `qstar` | `.raw` |
| PXD027299 | 2/4 | `Orbitrap Fusion Lumos` | `.raw, .wiff` |
| PXD032192 | 2/2 | `timsTOF Pro` | `.wiff` |
| PXD060714 | 2/5 | `Orbitrap Eclipse` | `.raw, .wiff` |
| PXD035252 | 1/3 | `Orbitrap Fusion Lumos` | `.raw, .wiff` |
| PXD042319 | 1/1 | `timsTOF Pro` | `.raw` |
| PXD072759 | 1/1 | `timsTOF Pro` | `.raw` |

</details>

**One of them is mine**, and it is instructive. `PXD079292` (from #61) declares `timsTOF HT` over 98 `.raw` files. PRIDE's dropdown says `Q Exactive HF` — which *matches* the file format — while the submitter's protocol says *"data-independent acquisition LC-MS/MS on a **timsTOF HT** mass spectrometer"*. I preferred the protocol at the time. The file format says the protocol may be wrong, or the files were converted. That is a genuine three-way conflict needing a human, and the check surfacing it as a question is exactly the intended behaviour.

If you would rather this land as advisory first (so the 44 are visible without any possibility of blocking), moving `instrument_cannot_write_data_file` into `ADVISORY` is a one-line change — say the word and I will push it.

Related: bigbio/sdrf-skills#71 carries this check plus the prose-based ones for annotators; #297 corrects 135 rows in #274 whose acquisition mode their run names contradict.
