### PR TITLE
Add tests for the review gate, and a workflow that actually runs them

### DIFF
--- a/.github/workflows/gate-tests.yml
+++ b/.github/workflows/gate-tests.yml
@@ -1,0 +1,35 @@
+# The review gate decides every dataset PR, but until now a change to it ran nothing:
+# sdrf-review.yml and validate-sdrf.yml are both path-filtered to datasets/**, so a PR
+# touching only .github/scripts/ triggered no checks at all.
+name: Review gate tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/gate-tests.yml'
+      - 'tests/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/**'
+      - 'tests/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # The gate itself imports nothing outside the standard library; pytest is the only
+      # dependency the tests need. sdrf-pipelines is deliberately not installed -- these
+      # tests cover the gate's own logic, and parse_sdrf is exercised by validate-sdrf.yml.
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Run review gate tests
+        run: python -m pytest tests/ -v --tb=short

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Make .github/scripts importable so the review gate can be tested directly.
+
+The gate lives in .github/scripts/ rather than an installable package, so there is no import
+path to it by default. Loading it by file keeps the script exactly where CI expects it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GATE_PATH = REPO_ROOT / ".github" / "scripts" / "sdrf_review.py"
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("sdrf_review", GATE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="session")
+def gate():
+    return _load_gate()
+
+
+@pytest.fixture
+def write_sdrf(tmp_path):
+    """Write a TSV from a header list and row lists; returns the path."""
+    def _write(header, rows, name="PXD000001.sdrf.tsv", root=None):
+        base = Path(root) if root else tmp_path
+        target = base / "datasets" / name.split(".")[0] / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        body = "\n".join(["\t".join(header)] + ["\t".join(r) for r in rows])
+        target.write_text(body + "\n", encoding="utf-8")
+        return target
+    return _write

--- a/tests/test_sdrf_review.py
+++ b/tests/test_sdrf_review.py
@@ -1,0 +1,233 @@
+"""Tests for the SDRF review gate in .github/scripts/sdrf_review.py.
+
+Every dataset PR in this repository is judged by this script, and until now a change to it
+ran nothing: both dataset workflows are path-filtered to `datasets/**`, so a PR touching only
+`.github/scripts/` triggered no checks at all.
+
+The cases below pin the behaviour the gate is relied on for, including the two things that
+are easy to break silently: the advisory/blocking split, and the `--baseline` subtraction that
+decides whether a pre-existing defect blocks an unrelated change.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+BASE_HEADER = [
+    "source name",
+    "characteristics[organism]",
+    "characteristics[organism part]",
+    "characteristics[disease]",
+    "characteristics[biological replicate]",
+    "assay name",
+    "technology type",
+    "comment[label]",
+    "comment[instrument]",
+    "comment[cleavage agent details]",
+    "comment[technical replicate]",
+    "comment[fraction identifier]",
+    "comment[data file]",
+    "comment[sdrf template]",
+    "factor value[disease]",
+]
+
+
+def row(src="PXD000001-Sample-1", organism="Homo sapiens", part="heart", disease="normal",
+        bio="1", assay="r1", label="NT=label free sample;AC=MS:1002038",
+        instrument="NT=Q Exactive;AC=MS:1001911", tech="1", frac="1", data="r1.raw",
+        template="NT=ms-proteomics;VV=v1.1.0", factor="normal"):
+    return [src, organism, part, disease, bio, assay,
+            "proteomic profiling by mass spectrometry", label, instrument,
+            "NT=Trypsin;AC=MS:1001251", tech, frac, data, template, factor]
+
+
+class TestStructuralCheck:
+    def test_clean_file_has_no_defects(self, gate, write_sdrf):
+        p = write_sdrf(BASE_HEADER, [row(assay="r1", data="r1.raw"),
+                                     row(src="PXD000001-Sample-2", assay="r2", data="r2.raw")])
+        assert gate.structural_check(str(p)) == (0, 0)
+
+    def test_ragged_row_is_counted(self, gate, write_sdrf):
+        good = row()
+        p = write_sdrf(BASE_HEADER, [good, good[:-2]])
+        ragged, _ = gate.structural_check(str(p))
+        assert ragged == 1
+
+    def test_coordinate_collision_is_counted(self, gate, write_sdrf):
+        # identical (source, bio rep, tech rep, fraction, label); only the file name differs,
+        # and comment[data file] is explicitly not an explainer
+        p = write_sdrf(BASE_HEADER, [row(assay="r1", data="r1.raw"),
+                                     row(assay="r2", data="r2.raw")])
+        _, collisions = gate.structural_check(str(p))
+        assert collisions == 1
+
+    def test_label_channels_are_not_a_collision(self, gate, write_sdrf):
+        """Multiplexed data legitimately repeats a coordinate once per label channel."""
+        p = write_sdrf(BASE_HEADER, [
+            row(label="NT=TMT126;AC=MS:1002623", data="mix.raw"),
+            row(label="NT=TMT127N;AC=MS:1002624", data="mix.raw"),
+        ])
+        assert gate.structural_check(str(p))[1] == 0
+
+    def test_a_descriptive_column_explains_a_repeated_coordinate(self, gate, write_sdrf):
+        """A second design axis carried in another column is annotation, not collision."""
+        p = write_sdrf(BASE_HEADER, [
+            row(part="heart", assay="r1", data="r1.raw"),
+            row(part="liver", assay="r2", data="r2.raw"),
+        ])
+        assert gate.structural_check(str(p))[1] == 0
+
+    def test_empty_file_is_safe(self, gate, tmp_path):
+        p = tmp_path / "empty.sdrf.tsv"
+        p.write_text("", encoding="utf-8")
+        assert gate.structural_check(str(p)) == (0, 0)
+
+
+class TestContentCheck:
+    def test_clean_file_reports_nothing(self, gate, write_sdrf):
+        p = write_sdrf(BASE_HEADER, [row(assay="r1", data="r1.raw"),
+                                     row(src="PXD000001-Sample-2", assay="r2", data="r2.raw")])
+        assert gate.content_check(str(p)) == {}
+
+    def test_reserved_word_must_be_lowercase(self, gate, write_sdrf):
+        p = write_sdrf(BASE_HEADER, [row(disease="Not Available", factor="Not Available")])
+        assert gate.content_check(str(p))["reserved_word_case"] >= 1
+
+    def test_characteristics_take_a_bare_label(self, gate, write_sdrf):
+        p = write_sdrf(BASE_HEADER, [row(part="NT=heart;AC=UBERON:0000948")])
+        assert gate.content_check(str(p))["characteristics_not_bare_label"] == 1
+
+    def test_pandas_artifact_header_is_detected(self, gate, write_sdrf):
+        header = list(BASE_HEADER)
+        header[13] = "comment[sdrf template].1"
+        p = write_sdrf(header, [row()])
+        assert gate.content_check(str(p))["artifact_headers"] == 1
+
+    def test_peak_list_data_file_is_advisory(self, gate, write_sdrf):
+        p = write_sdrf(BASE_HEADER, [row(data="r1.mzML")])
+        found = gate.content_check(str(p))
+        assert found["peak_list_data_file"] == 1
+        assert "peak_list_data_file" in gate.ADVISORY
+
+    def test_missing_factor_value_is_advisory(self, gate, write_sdrf):
+        header = BASE_HEADER[:-1]
+        p = write_sdrf(header, [row()[:-1]])
+        found = gate.content_check(str(p))
+        assert found["no_factor_value"] == 1
+        assert "no_factor_value" in gate.ADVISORY
+
+    def test_all_sentinel_factor_is_hollow_and_blocks(self, gate, write_sdrf):
+        p = write_sdrf(BASE_HEADER, [row(factor="not available"),
+                                     row(src="PXD000001-Sample-2", assay="r2",
+                                         data="r2.raw", factor="not available")])
+        found = gate.content_check(str(p))
+        assert found["hollow_factor_value"] == 1
+        assert "hollow_factor_value" not in gate.ADVISORY
+
+    def test_a_constant_real_factor_is_not_hollow(self, gate, write_sdrf):
+        """A single-condition study has no contrast; the corpus norm is a constant value."""
+        p = write_sdrf(BASE_HEADER, [row(factor="dilated cardiomyopathy"),
+                                     row(src="PXD000001-Sample-2", assay="r2",
+                                         data="r2.raw", factor="dilated cardiomyopathy")])
+        assert "hollow_factor_value" not in gate.content_check(str(p))
+
+
+class TestInstrumentVendorCheck:
+    """A vendor's acquisition software writes its own container format."""
+
+    @pytest.mark.parametrize("instrument,files,expected", [
+        ("Q Exactive", ["a.d.zip", "b.d.zip"], 2),        # Thermo model, Bruker files
+        ("timsTOF Pro", ["a.raw"], 1),                     # Bruker model, Thermo file
+        ("Q Exactive", ["a.raw", "b.raw"], 0),
+        ("timsTOF Pro", ["a.d.zip"], 0),
+        ("Q Exactive", ["a.mzML"], 0),                     # converted, vendor-neutral
+        ("Some Unlisted Analyzer", ["a.d"], 0),            # unrecognised model: silent
+    ])
+    def test_vendor_and_format(self, gate, instrument, files, expected):
+        assert gate.instrument_vendor_check({instrument}, files) == expected
+
+    def test_several_instruments_any_may_match(self, gate):
+        assert gate.instrument_vendor_check({"Q Exactive", "timsTOF Pro"},
+                                            ["a.raw", "b.d.zip"]) == 0
+
+    def test_no_files_is_silent(self, gate):
+        assert gate.instrument_vendor_check({"Q Exactive"}, []) == 0
+
+    def test_reported_through_content_check(self, gate, write_sdrf):
+        p = write_sdrf(BASE_HEADER, [row(instrument="NT=Q Exactive;AC=MS:1001911",
+                                         data="a.d.zip")])
+        assert gate.content_check(str(p))["instrument_cannot_write_data_file"] == 1
+
+
+class TestDeclaredTemplates:
+    def test_parameter_spelling(self, gate, write_sdrf):
+        p = write_sdrf(BASE_HEADER, [row(template="NT=ms-proteomics;VV=v1.1.0")])
+        assert gate.declared_templates(str(p)) == ["ms-proteomics"]
+
+    def test_plain_spelling(self, gate, write_sdrf):
+        p = write_sdrf(BASE_HEADER, [row(template="ms-proteomics v1.1.0")])
+        assert gate.declared_templates(str(p)) == ["ms-proteomics"]
+
+    def test_repeated_column_collects_every_template(self, gate, write_sdrf):
+        """A DIA file declares two templates in two columns of the same name.
+
+        A plain csv.DictReader would keep only the last, so the gate reads raw indices.
+        """
+        header = list(BASE_HEADER) + ["comment[sdrf template]"]
+        p = write_sdrf(header, [row() + ["NT=dia-acquisition;VV=v1.1.0"]])
+        assert gate.declared_templates(str(p)) == ["ms-proteomics", "dia-acquisition"]
+
+    def test_sentinel_is_not_a_template(self, gate, write_sdrf):
+        p = write_sdrf(BASE_HEADER, [row(template="not available")])
+        assert gate.declared_templates(str(p)) == []
+
+    def test_no_column_returns_empty(self, gate, write_sdrf):
+        header = [c for c in BASE_HEADER if c != "comment[sdrf template]"]
+        r = [v for c, v in zip(BASE_HEADER, row()) if c != "comment[sdrf template]"]
+        p = write_sdrf(header, [r])
+        assert gate.declared_templates(str(p)) == []
+
+
+class TestBaselinePath:
+    def test_relative_path_resolves_inside_the_baseline(self, gate):
+        got = gate._baseline_path("/base", "datasets/PXD1/PXD1.sdrf.tsv")
+        assert str(got) == "/base/datasets/PXD1/PXD1.sdrf.tsv"
+
+    def test_absolute_path_does_not_escape_the_baseline(self, gate):
+        """Path('/base') / '/abs' returns '/abs', which would make the baseline the file
+        itself and silently disable every check."""
+        got = gate._baseline_path("/base", "/abs/datasets/PXD1/PXD1.sdrf.tsv")
+        assert str(got).startswith("/base/")
+
+
+class TestBaselineSubtraction:
+    """The mechanism that decides whether a pre-existing defect blocks an unrelated change.
+
+    Nothing else exercises it, and every new gate rule depends on it behaving this way.
+    """
+
+    def _counts(self, gate, before, after):
+        base = gate.content_check(str(before))
+        head = gate.content_check(str(after))
+        return {k: v - base.get(k, 0) for k, v in head.items() if v - base.get(k, 0) > 0}
+
+    def test_unchanged_pre_existing_defect_is_not_new(self, gate, write_sdrf, tmp_path):
+        bad = [row(part="NT=heart;AC=UBERON:0000948")]
+        before = write_sdrf(BASE_HEADER, bad, root=tmp_path / "base")
+        after = write_sdrf(BASE_HEADER, bad, root=tmp_path / "head")
+        assert self._counts(gate, before, after) == {}
+
+    def test_an_increase_is_reported(self, gate, write_sdrf, tmp_path):
+        before = write_sdrf(BASE_HEADER, [row(part="NT=heart;AC=UBERON:0000948")],
+                            root=tmp_path / "base")
+        after = write_sdrf(BASE_HEADER, [row(part="NT=heart;AC=UBERON:0000948"),
+                                         row(src="PXD000001-Sample-2", assay="r2", data="r2.raw",
+                                             part="NT=liver;AC=UBERON:0002107")],
+                           root=tmp_path / "head")
+        assert self._counts(gate, before, after)["characteristics_not_bare_label"] == 1
+
+    def test_a_fix_is_not_reported_as_a_defect(self, gate, write_sdrf, tmp_path):
+        before = write_sdrf(BASE_HEADER, [row(part="NT=heart;AC=UBERON:0000948")],
+                            root=tmp_path / "base")
+        after = write_sdrf(BASE_HEADER, [row(part="heart")], root=tmp_path / "head")
+        assert self._counts(gate, before, after) == {}


### PR DESCRIPTION
@ypriverol — this is a follow-up to #298 rather than a change to any dataset, so it needs your call on whether the repository should carry a test suite at all. There is no `tests/` directory today, so this establishes a convention as much as it adds coverage.

## The gap

`.github/scripts/sdrf_review.py` decides every dataset PR here. **A change to it currently runs nothing.** `sdrf-review.yml` and `validate-sdrf.yml` are both path-filtered to `datasets/**`, so a PR touching only `.github/scripts/` triggers no checks.

#298 was exactly that: it changed the gate's logic and only CodeRabbit ran. That merged on my manual testing alone, which is not a good basis for a script the whole repository depends on.

## What this adds

**33 tests**, covering `structural_check`, `content_check`, `declared_templates`, `_baseline_path` and `instrument_vendor_check` — plus the two behaviours that are easiest to break silently and that nothing else exercises:

- **The advisory/blocking split.** `peak_list_data_file` and `no_factor_value` must not fail a PR; `hollow_factor_value` must. A constant *real* factor value is the corpus norm and must not be flagged as hollow.
- **The `--baseline` subtraction.** This is the mechanism that decides whether a pre-existing defect blocks an unrelated change, and it is what makes it safe to add any new rule to the gate. Tested three ways: an unchanged pre-existing defect is not new, an increase is reported, and a fix is not misreported as a defect.

It also pins the behaviours that were deliberately built in and would be easy to "simplify" away:

- a label channel repeating a coordinate is **not** a collision (multiplexed data legitimately does this);
- a repeated coordinate that another descriptive column separates completely is annotation, not collision;
- `declared_templates` reads **all** `comment[sdrf template]` indices, so a DIA file declaring two templates is not truncated to one — a plain `csv.DictReader` would keep only the last;
- `_baseline_path` does not let an absolute path escape the baseline tree, which would silently disable every check.

## The suite was mutation-checked, not just run

Passing tests prove nothing on their own, so I broke the gate three ways and confirmed each is caught:

| Mutation | Result |
|---|---|
| `instrument_vendor_check` always returns 0 | **3 tests fail** |
| `hollow_factor_value` moved into `ADVISORY` | **1 test fails** |
| `declared_templates` reads only the first matching column | **1 test fails** |

The gate was restored byte-identical afterwards; `git diff` against `main` for `sdrf_review.py` is empty. **This PR changes no gate behaviour.**

## Cost

`pytest` is the only dependency — the gate imports nothing outside the standard library, and `sdrf-pipelines` is deliberately not installed here, so the job is a few seconds. `parse_sdrf` stays covered by `validate-sdrf.yml` where it belongs.

The new workflow triggers only on `.github/scripts/**`, `tests/**` and its own file, so it adds nothing to a normal dataset PR.

## If you would rather not

Reasonable alternatives, in case a test directory is not something you want here: keep the tests and drop the workflow (so they are runnable but not automatic), or narrow the suite to `instrument_vendor_check` and the baseline behaviour and drop the rest. Say which and I will push it.
